### PR TITLE
Improve handling of outdoor unit

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -25,6 +25,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
 
   // Used to track restored cached accessories
   private readonly accessories: PlatformAccessory<PanasonicAccessoryContext>[] = [];
+  private outdoorUnit: OutdoorUnitAccessory | undefined;
 
   public readonly comfortCloud: ComfortCloudApi;
   public readonly log: PanasonicPlatformLogger;
@@ -85,7 +86,8 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
       this.log.info('Attempting to log into Comfort Cloud.');
       this.comfortCloud.login()
         .then(() => {
-          this.log.info('Successfully logged in. Starting device discovery.');
+          this.log.info('Successfully logged in.');
+          this.configureOutdoorUnit();
           this.discoverDevices();
         })
         .catch(() => {
@@ -114,48 +116,61 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
   }
 
   /**
+   * Adds or removes the outdoor unit as separate accessory,
+   * depending on the user's configuration.
+   */
+  configureOutdoorUnit() {
+    this.log.info('Configuring outdoor unit.');
+
+    try {
+      // We'll use a dummy identifier because the Comfort Cloud API
+      // doesn't expose the outdoor unit as separate device.
+      const outdoorUnitUUID = this.api.hap.uuid.generate('Panasonic-AC-Outdoor-Unit');
+      const outdoorUnitName = 'Panasonic AC Outdoor Unit';
+
+      const existingAccessory = this.accessories.find(
+        accessory => accessory.UUID === outdoorUnitUUID);
+
+      // Create an accessory for the outdoor unit if enabled.
+      // The outdoor unit reports the outdoor temperature via its own sensor.
+      if (this.platformConfig.exposeOutdoorUnit) {
+        if (existingAccessory !== undefined) {
+          // The accessory already exists, we only need to set up its handlers.
+          this.log.info(`Restoring accessory '${existingAccessory.displayName}' ` +
+            `(${existingAccessory.UUID}) from cache.`);
+          this.outdoorUnit = new OutdoorUnitAccessory(this, existingAccessory);
+        } else {
+          // The accessory does not yet exist, so we need to create it.
+          this.log.info(`Adding accessory '${outdoorUnitName}' (${outdoorUnitUUID}).`);
+          const accessory = new this.api.platformAccessory(outdoorUnitName, outdoorUnitUUID);
+          this.outdoorUnit = new OutdoorUnitAccessory(this, accessory);
+          this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+        }
+      } else {
+        if (existingAccessory !== undefined) {
+          // This accessory is no longer needed.
+          this.log.info(`Removing accessory '${existingAccessory.displayName}' ` +
+            `(${existingAccessory.UUID}) `);
+          this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
+        }
+      }
+    } catch (error) {
+      this.log.error('An error occurred while configuring the outdoor unit:');
+      this.log.error(error);
+    }
+  }
+
+  /**
    * Fetches all of the user's devices from Comfort Cloud and sets up handlers.
    *
    * Accessories must only be registered once. Previously created accessories
    * must not be registered again to prevent "duplicate UUID" errors.
    */
   async discoverDevices() {
-    this.log.info('Now discovering devices on Comfort Cloud.');
+    this.log.info('Discovering devices on Comfort Cloud.');
 
     try {
       const comfortCloudDevices = await this.comfortCloud.getDevices();
-      let outdoorUnit: OutdoorUnitAccessory | undefined;
-
-      // Create an accessory for the outdoor unit if enabled.
-      // The outdoor unit reports the outdoor temperature via its own sensor.
-      if (this.platformConfig.exposeOutdoorUnit && comfortCloudDevices.length > 0) {
-        // We'll use a dummy identifier because the Comfort Cloud API
-        // doesn't expose the outdoor unit as separate device,
-        const outdoorUnitUUID = this.api.hap.uuid.generate('Panasonic-AC-Outdoor-Unit');
-        const outdoorUnitName = 'Panasonic AC Outdoor Unit';
-
-        const existingAccessory = this.accessories.find(
-          accessory => accessory.UUID === outdoorUnitUUID);
-
-        if (existingAccessory !== undefined) {
-          // The accessory already exists
-          this.log.info(`Restoring accessory '${existingAccessory.displayName}' ` +
-            `(${existingAccessory.UUID}) from cache.`);
-
-          // Create the accessory handler for the restored accessory
-          outdoorUnit = new OutdoorUnitAccessory(this, existingAccessory);
-        } else {
-          this.log.info(`Adding accessory '${outdoorUnitName}' (${outdoorUnitUUID}).`);
-          // The accessory does not yet exist, so we need to create it
-          const accessory = new this.api.platformAccessory(outdoorUnitName, outdoorUnitUUID);
-
-          // Create the accessory handler for the newly create accessory
-          outdoorUnit = new OutdoorUnitAccessory(this, accessory);
-
-          // Link the accessory to your platform
-          this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
-        }
-      }
 
       // Loop over the discovered (indoor) devices and register each
       // one if it has not been registered before.
@@ -181,7 +196,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
           this.api.updatePlatformAccessories([existingAccessory]);
 
           // Create the accessory handler for the restored accessory
-          new IndoorUnitAccessory(this, existingAccessory, outdoorUnit);
+          new IndoorUnitAccessory(this, existingAccessory, this.outdoorUnit);
         } else {
           this.log.info(`Adding accessory '${device.deviceName}' (${device.deviceGuid}).`);
           // The accessory does not yet exist, so we need to create it
@@ -194,7 +209,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
 
           // Create the accessory handler for the newly create accessory
           // this is imported from `platformAccessory.ts`
-          new IndoorUnitAccessory(this, accessory, outdoorUnit);
+          new IndoorUnitAccessory(this, accessory, this.outdoorUnit);
 
           // Link the accessory to your platform
           this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
@@ -204,15 +219,19 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
       // At this point, we set up all devices from Comfort Cloud, but we did not unregister
       // cached devices that do not exist on the Comfort Cloud account anymore.
       for (const cachedAccessory of this.accessories) {
-        const guid = cachedAccessory.context.device.deviceGuid;
-        const comfortCloudDevice = comfortCloudDevices.find(device => device.deviceGuid === guid);
+        // Only indoor units have context.device set and we don't
+        // want to delete the outdoor unit here which is managed above.
+        if (cachedAccessory.context.device) {
+          const guid = cachedAccessory.context.device.deviceGuid;
+          const comfortCloudDevice = comfortCloudDevices.find(device => device.deviceGuid === guid);
 
-        if (comfortCloudDevice === undefined) {
-          // This cached devices does not exist on the Comfort Cloud account (anymore).
-          this.log.info(`Removing accessory '${cachedAccessory.displayName}' (${guid}) ` +
-            'because it does not exist on the Comfort Cloud account (anymore?).');
+          if (comfortCloudDevice === undefined) {
+            // This cached devices does not exist on the Comfort Cloud account (anymore).
+            this.log.info(`Removing accessory '${cachedAccessory.displayName}' (${guid}) ` +
+              'because it does not exist on the Comfort Cloud account (anymore?).');
 
-          this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [cachedAccessory]);
+            this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [cachedAccessory]);
+          }
         }
       }
     } catch (error) {


### PR DESCRIPTION
Add functionality to remove the cached outdoor unit accessory
when the the exposeOutdoorUnit setting is changed over time.

Improve code organisation for the setup of the outdoor and
indoor unit(s).