### PR TITLE
Add flexible configuration for app version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,27 +31,36 @@ Configure the plugin through the settings UI or directly in the JSON editor:
         "password": "********",
         "exposeOutdoorUnit": true,
         "debugMode": false,
-        "appVersion": "1.14.0"
+        "appVersionOverride": "1.14.0"
     }
   ]
 }
 ```
 
-Description:
+Required:
 
-* `platform` (string): Tells Homebridge which platform this config belongs to. Leave as is.
+* `platform` (string):
+Tells Homebridge which platform this config belongs to. Leave as is.
 
-* `name` (string): Will be displayed in the Homebridge log.
+* `name` (string):
+Will be displayed in the Homebridge log.
 
-* `email` (string): The username of your Comfort Cloud account.
+* `email` (string):
+The username of your Comfort Cloud account.
 
-* `password` (string): The password of your account.
+* `password` (string):
+The password of your account.
 
-* `exposeOutdoorUnit (boolean)`: If `true`, the plugin will create a separate accessory for your outdoor unit which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.
+Optional:
 
-* `debugMode` (boolean): If `true`, the plugin will print debugging information to the Homebridge log.
+* `exposeOutdoorUnit` (boolean):
+If `true`, the plugin will create a separate accessory for your outdoor unit which will display the (outdoor) temperature it measures. This can be used for monitoring and automation purposes.
 
-* `appVersion` (string): This should match the latest app version on the App Store.
+* `debugMode` (boolean):
+If `true`, the plugin will print debugging information to the Homebridge log.
+
+* `appVersionOverride` (string): 
+The plugin will automatically use the last known working value when this setting is empty or undefined (default). This setting allows you to override the default value if needed. It should reflect the latest version on the App Store, although older clients might remain supported for some time.
 
 ## Troubleshooting
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -39,13 +39,11 @@
         "type": "boolean",
         "default": false
       },
-      "appVersion": {
-        "title": "Emulated Comfort Cloud app version",
-        "description": "Should ideally reflect the same version as on the app store(s), although older clients might remain supported for some time.",
+      "appVersionOverride": {
+        "title": "Emulated Comfort Cloud app version (override)",
+        "description": "The plugin will automatically use the last known working value when this setting is empty or undefined (default). This setting allows you to override the default value if needed. It should reflect the latest version on the App Store, although older clients might remain supported for some time.",
         "type": "string",
-        "default": "1.14.0",
-        "placeholder": "1.14.0",
-        "required": true
+        "placeholder": "1.14.0"
       }
     }
   },
@@ -84,7 +82,7 @@
       "expandable": true,
       "items": [
         "debugMode",
-        "appVersion"
+        "appVersionOverride"
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-panasonic-ac-platform",
   "displayName": "Homebridge Panasonic AC Platform",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Homebridge platform plugin providing HomeKit support for Panasonic air conditioners.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/comfort-cloud.ts
+++ b/src/comfort-cloud.ts
@@ -1,6 +1,7 @@
 import PanasonicPlatformLogger from './logger';
 import axios, { AxiosError } from 'axios';
 import {
+  APP_VERSION,
   COMFORT_CLOUD_USER_AGENT,
   LOGIN_RETRY_DELAY,
   LOGIN_TOKEN_REFRESH_INTERVAL,
@@ -56,7 +57,7 @@ export default class ComfortCloudApi {
         'Content-Type': 'application/json',
         'User-Agent': COMFORT_CLOUD_USER_AGENT,
         'X-APP-TYPE': '0',
-        'X-APP-VERSION': this.config.appVersion,
+        'X-APP-VERSION': this.config.appVersionOverride || APP_VERSION,
       },
       data: {
         'loginId': this.config.email,
@@ -114,7 +115,7 @@ export default class ComfortCloudApi {
         'Content-Type': 'application/json',
         'User-Agent': COMFORT_CLOUD_USER_AGENT,
         'X-APP-TYPE': '0',
-        'X-APP-VERSION': this.config.appVersion,
+        'X-APP-VERSION': this.config.appVersionOverride || APP_VERSION,
         'X-User-Authorization': this.token,
       },
     })
@@ -162,7 +163,7 @@ export default class ComfortCloudApi {
         'Content-Type': 'application/json',
         'User-Agent': COMFORT_CLOUD_USER_AGENT,
         'X-APP-TYPE': '0',
-        'X-APP-VERSION': this.config.appVersion,
+        'X-APP-VERSION': this.config.appVersionOverride || APP_VERSION,
         'X-User-Authorization': this.token,
       },
     })
@@ -202,7 +203,7 @@ export default class ComfortCloudApi {
         'Content-Type': 'application/json',
         'User-Agent': COMFORT_CLOUD_USER_AGENT,
         'X-APP-TYPE': '0',
-        'X-APP-VERSION': this.config.appVersion,
+        'X-APP-VERSION': this.config.appVersionOverride || APP_VERSION,
         'X-User-Authorization': this.token,
       },
       data: {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -77,12 +77,6 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
         return;
       }
 
-      if (!this.platformConfig.appVersion) {
-        this.log.error('App version is not configured - aborting plugin start. ' +
-          'Please set the field `appVersion` in your config and restart Homebridge.');
-        return;
-      }
-
       this.log.info('Attempting to log into Comfort Cloud.');
       this.comfortCloud.login()
         .then(() => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@ export const PLUGIN_NAME = 'homebridge-panasonic-ac-platform';
 export const PLATFORM_NAME = 'Panasonic AC Platform';
 
 export const COMFORT_CLOUD_USER_AGENT = 'G-RAC';
+export const APP_VERSION = '1.14.0';
 
 // 360 sec = 6 min
 export const LOGIN_RETRY_DELAY = 360 * 1000;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface PanasonicPlatformConfig extends PlatformConfig {
   email: string;
   password: string;
   debugMode: boolean;
-  appVersion: string;
+  appVersionOverride: string;
   exposeOutdoorUnit: boolean;
 }
 


### PR DESCRIPTION
Ship a hard-coded value but accept an override value to allow fast adaption outside the standard release process.