### PR TITLE
Add adjustment option for heating temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Configure the plugin through the settings UI or directly in the JSON editor:
         "password": "********",
         "exposeOutdoorUnit": true,
         "debugMode": false,
-        "appVersionOverride": "1.14.0"
+        "appVersionOverride": "1.14.0",
+        "suppressOutgoingUpdates": false,
+        "minHeatingTemperature": 16
     }
   ]
 }
@@ -61,8 +63,14 @@ If `true`, the plugin will create a separate accessory for your outdoor unit whi
 * `debugMode` (boolean):
 If `true`, the plugin will print debugging information to the Homebridge log.
 
-* `appVersionOverride` (string): 
+* `appVersionOverride` (string):
 The plugin will automatically use the last known working value when this setting is empty or undefined (default). This setting allows you to override the default value if needed. It should reflect the latest version on the App Store, although older clients might remain supported for some time.
+
+* `suppressOutgoingUpdates` (boolean):
+If `true`, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC to minimise wear and tear.
+
+* `minHeatingTemperature` (integer):
+The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.
 
 ## Troubleshooting
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -52,7 +52,7 @@
       },
       "minHeatingTemperature": {
         "title": "Minimum heating temperature (override)",
-        "description": "The plugin will set the heating temperature range to 16-30°C by default. Some Panasonic ACs have an additional heating mode for the range of 8-15°C, in addition to the default heating mode. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.",
+        "description": "The default heating temperature range is 16-30°C. Some Panasonic ACs have an additional heating mode for the range of 8-15°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.",
         "type": "integer",
         "placeholder": "16"
       }

--- a/config.schema.json
+++ b/config.schema.json
@@ -52,7 +52,7 @@
       },
       "minHeatingTemperature": {
         "title": "Minimum heating temperature (override)",
-        "description": "The plugin will set the heating temperature range to 16-30°C by default. Some Panasonic ACs have an additional heating mode for the range of 8-15°C, in addition to the default heating mode from 16-30°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.",
+        "description": "The plugin will set the heating temperature range to 16-30°C by default. Some Panasonic ACs have an additional heating mode for the range of 8-15°C, in addition to the default heating mode. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.",
         "type": "integer",
         "placeholder": "16"
       }

--- a/config.schema.json
+++ b/config.schema.json
@@ -44,6 +44,12 @@
         "description": "The plugin will automatically use the last known working value when this setting is empty or undefined (default). This setting allows you to override the default value if needed. It should reflect the latest version on the App Store, although older clients might remain supported for some time.",
         "type": "string",
         "placeholder": "1.14.0"
+      },
+      "minHeatingTemperature": {
+        "title": "Minimum heating temperature (override)",
+        "description": "The plugin will set the heating temperature range to 16-30°C by default. Some Panasonic ACs have an additional heating mode for the range of 8-15°C, in addition to the default heating mode from 16-30°C. If you own such a model, you can use this setting to adjust the minimum value. Leave it empty or undefined to use the default value.",
+        "type": "integer",
+        "placeholder": "16"
       }
     }
   },
@@ -82,7 +88,8 @@
       "expandable": true,
       "items": [
         "debugMode",
-        "appVersionOverride"
+        "appVersionOverride",
+        "minHeatingTemperature"
       ]
     }
   ]

--- a/config.schema.json
+++ b/config.schema.json
@@ -39,6 +39,11 @@
         "type": "boolean",
         "default": false
       },
+      "suppressOutgoingUpdates": {
+        "title": "Suppress outgoing device updates",
+        "description": "When enabled, changes in the Home app will not be sent to Comfort Cloud. Useful for testing your installation without constantly switching the state of your AC to minimise wear and tear.",
+        "type": "boolean"
+      },
       "appVersionOverride": {
         "title": "Emulated Comfort Cloud app version (override)",
         "description": "The plugin will automatically use the last known working value when this setting is empty or undefined (default). This setting allows you to override the default value if needed. It should reflect the latest version on the App Store, although older clients might remain supported for some time.",
@@ -88,6 +93,7 @@
       "expandable": true,
       "items": [
         "debugMode",
+        "suppressOutgoingUpdates",
         "appVersionOverride",
         "minHeatingTemperature"
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-panasonic-ac-platform",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-panasonic-ac-platform",
   "displayName": "Homebridge Panasonic AC Platform",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Homebridge platform plugin providing HomeKit support for Panasonic air conditioners.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -99,7 +99,7 @@ export default class IndoorUnitAccessory {
     this.service
       .getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
       .setProps({
-        minValue: 16,
+        minValue: this.platform.platformConfig.minHeatingTemperature || 16,
         maxValue: 30,
         minStep: 0.5,
       })

--- a/src/comfort-cloud.ts
+++ b/src/comfort-cloud.ts
@@ -203,6 +203,11 @@ export default class ComfortCloudApi {
       return Promise.reject('Cannot set device status for undefined deviceGuid.');
     }
 
+    if (this.config.suppressOutgoingUpdates) {
+      this.log.debug('Suppressing outgoing device update.');
+      return;
+    }
+
     return axios.request({
       method: 'post',
       url: 'https://accsmart.panasonic.com/deviceStatus/control',

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -30,7 +30,7 @@ export default class PanasonicPlatform implements DynamicPlatformPlugin {
   public readonly comfortCloud: ComfortCloudApi;
   public readonly log: PanasonicPlatformLogger;
 
-  private readonly platformConfig: PanasonicPlatformConfig;
+  public readonly platformConfig: PanasonicPlatformConfig;
 
   /**
    * This constructor is where you should parse the user config

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface PanasonicPlatformConfig extends PlatformConfig {
   email: string;
   password: string;
   debugMode: boolean;
+  suppressOutgoingUpdates?: boolean;
   appVersionOverride: string;
   exposeOutdoorUnit: boolean;
   minHeatingTemperature?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface PanasonicPlatformConfig extends PlatformConfig {
   debugMode: boolean;
   appVersionOverride: string;
   exposeOutdoorUnit: boolean;
+  minHeatingTemperature?: number;
 }
 
 export interface PanasonicAccessoryContext {


### PR DESCRIPTION
Specifically to allow users to adjust the lower boundary of the heating threshold temperature.

This PR also contains a new option to suppress outgoing device updates for testing purposes.