### PR TITLE
Change 'Cooling Threshold Temperature' to be compliant with Homebridg…

### DIFF
--- a/src/accessories/indoor-unit.ts
+++ b/src/accessories/indoor-unit.ts
@@ -89,7 +89,7 @@ export default class IndoorUnitAccessory {
     this.service
       .getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
       .setProps({
-        minValue: 16,
+        minValue: 10,
         maxValue: 30,
         minStep: 0.5,
       })
@@ -99,7 +99,7 @@ export default class IndoorUnitAccessory {
     this.service
       .getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
       .setProps({
-        minValue: 16,
+        minValue: 0,
         maxValue: 30,
         minStep: 0.5,
       })


### PR DESCRIPTION
…e specs.

Homebridge is throwing out warnings like 

    [homebridge-panasonic-ac-platform] This plugin generated a warning from the characteristic 'Heating Threshold Temperature': characteristic was supplied illegal value: number 11.5 exceeded minimum of 16. See https://git.io/JtMGR for more info.'

According to the specs (https://developers.homebridge.io/#/characteristic/CoolingThresholdTemperature), the minimum value is 10.
Likewise for HeatingThresholdTemperature, the minimum is 0.