### PR TITLE
Improve login error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Configure the plugin through the settings UI or directly in the JSON editor:
         "password": "********",
         "exposeOutdoorUnit": true,
         "debugMode": false,
-        "appVersionOverride": "1.16.0",
+        "appVersionOverride": "1.17.0",
         "suppressOutgoingUpdates": false,
         "minHeatingTemperature": 16
     }
@@ -74,7 +74,11 @@ The default heating temperature range is 16-30°C. Some Panasonic ACs have an ad
 
 ## Troubleshooting
 
-If you have any issues with this plugin, enable the debug mode in the settings (and restart the plugin). This will print additional information to the log. If this doesn't help you resolve the issue, feel free to create a [GitHub issue](https://github.com/embee8/homebridge-panasonic-ac-platform/issues) and attach the available debugging information.
+- If you have any issues with this plugin, enable the debug mode in the settings (and restart the plugin). This will print additional information to the log. If this doesn't help you resolve the issue, feel free to create a [GitHub issue](https://github.com/embee8/homebridge-panasonic-ac-platform/issues) and attach the available debugging information.
+
+- If you run into login errors despite using the correct login details, make sure you accepted the latest terms and conditions after logging into the Comfort Cloud app.
+
+- If the plugin affects the general responsiveness and reliability of your Homebridge setup, you can run it as an isolated [child bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges).
 
 ## Contributing
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -48,7 +48,7 @@
         "title": "Emulated Comfort Cloud app version (override)",
         "description": "The plugin will automatically fetch the latest version number from the App Store. If that fails, it will use the last known working value which is hard-coded. This setting allows you to override both of these if needed. It should normally reflect the latest version on the App Store.",
         "type": "string",
-        "placeholder": "1.16.0"
+        "placeholder": "1.17.0"
       },
       "minHeatingTemperature": {
         "title": "Minimum heating temperature (override)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-panasonic-ac-platform",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-panasonic-ac-platform",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-panasonic-ac-platform",
   "displayName": "Homebridge Panasonic AC Platform",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Homebridge platform plugin providing HomeKit support for Panasonic air conditioners.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,10 +5,12 @@ export const PLUGIN_NAME = 'homebridge-panasonic-ac-platform';
 export const PLATFORM_NAME = 'Panasonic AC Platform';
 
 export const COMFORT_CLOUD_USER_AGENT = 'G-RAC';
-export const APP_VERSION = '1.16.0';
+export const APP_VERSION = '1.17.0';
 
 // 360 sec = 6 min
 export const LOGIN_RETRY_DELAY = 360 * 1000;
+
+export const MAX_NO_OF_FAILED_LOGIN_ATTEMPTS = 5;
 
 // Used to renew the token periodically. Only a safety measure, since we are handling
 // network errors dynamically and re-issuing a login upon a 401 Unauthorized error.


### PR DESCRIPTION
- Introduce a maximum number of login retry attempts.
- Remove per-device login retries on the back of device status updates.
- Add troubleshooting instructions for login errors (see README).
- Increase app version number.

Resolves #48, #54, #56, and #57.